### PR TITLE
Fix casting `usize` to `u8` at `pallet::error` macro (reapplying #68)

### DIFF
--- a/frame/support/procedural/src/pallet/expand/error.rs
+++ b/frame/support/procedural/src/pallet/expand/error.rs
@@ -152,11 +152,11 @@ pub fn expand_error(def: &mut Def) -> proc_macro2::TokenStream {
 		{
 			fn from(err: #error_ident<#type_use_gen>) -> Self {
 				use #frame_support::codec::Encode;
-				let index = <
+				let index: u8 = <
 					<T as #frame_system::Config>::PalletInfo
 					as #frame_support::traits::PalletInfo
 				>::index::<Pallet<#type_use_gen>>()
-					.expect("Every active module has an index in the runtime; qed") as u8;
+					.expect("Every active module has an index in the runtime; qed").try_into().expect("Index should fit into u8");
 				let mut encoded = err.encode();
 				encoded.resize(#frame_support::MAX_MODULE_ERROR_ENCODED_SIZE, 0);
 


### PR DESCRIPTION
Apply the patch https://github.com/humanode-network/substrate/pull/68